### PR TITLE
Adicionar data aos relatórios e impressões

### DIFF
--- a/script.js
+++ b/script.js
@@ -726,7 +726,7 @@ async function displayStoreReport(storeCode) {
                     <div class="report-item service-report">
                             <div class="report-item-header">
                             <span class="report-item-title">${svc.machineCode} - ${svc.machineType}</span>
-                            <span class="report-item-date">Serviço: ${getServiceNumber(storeCode, svc.id || svc._id || '')}</span>
+                            <span class="report-item-date">Serviço: ${getServiceNumber(storeCode, svc.id || svc._id || '')} • Data: ${(() => { try { return svc.serviceDate ? new Date(svc.serviceDate).toLocaleDateString('pt-BR') : ''; } catch(e) { return svc.serviceDate || ''; } })()}</span>
                             </div>
                             <div class="report-item-details">
                             <strong>Tipo de Serviço:</strong> ${svc.serviceType}<br>


### PR DESCRIPTION
Adiciona a data do serviço nos cards da seção de relatórios para atender à solicitação do usuário de exibir a data em relatórios e impressões.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ef1855c-4e3f-4f2c-b937-44d4fe4dad60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ef1855c-4e3f-4f2c-b937-44d4fe4dad60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

